### PR TITLE
Add new minutes and update presentations

### DIFF
--- a/minutes/2021-07-06.md
+++ b/minutes/2021-07-06.md
@@ -1,0 +1,38 @@
+# Parsec Community Meeting (06/07/2021) 📋
+
+Minutes of previous meeting are stored
+[here](https://github.com/parallaxsecond/community/tree/main/minutes).
+
+## Attendance
+
+- Matt Davis
+- Sam Davis
+- Paul Howard
+- Marc Meunier
+- Ionut Mihalcea
+- Hugues de Valon
+
+## Agenda
+
+1. Read-only attributes in some PKCS11 implementations: what to do? See
+   [here](https://github.com/parallaxsecond/parsec/issues/462).
+2. 0.8.0 review
+
+## Minutes
+
+- Could be fine to add a new specific configuration flag now (just for those two attributes) and
+   generalise it later (and maybe deprecate it then).
+- Having a blocklist of PKCS11 attributes could mean that some of the PSA Crypto contracts won't be
+   respected (if a key is successfully created as exportable but can't be for exemple).
+- For completeness, it could be possible to create a key set as exportable in software using Mbed
+   Crypto, so that it can be exported. Could present more security issues though.
+- To respect the PSA Crypto API, a `PsaErrorNotSupported` could be returned if a key is created with
+   the `export` flag set to true. Better than ignoring flags that fundamentally change the nature of
+   the key.
+- A new flag will be added to prevent creating a new key set as exportable.
+- The issue above is to enable Parsec on the NXP Layerscape platform. It would be great for Parsec
+   to be integrated in the Layerscape SDK.
+- Key attestation design: the rework of the proposal is being finished with new protobuf contract
+   and configuration change.
+
+*Copyright 2021 Contributors to the Parsec project.*

--- a/presentations.md
+++ b/presentations.md
@@ -12,9 +12,10 @@ These presentations give an overview of what Parsec is.
 | 2020-08-17 | [Cloud Native Security Day](https://youtu.be/bYFQXcPSf0I)                                    |
 | 2020-09-22 | [Linaro Virtual Connect](https://youtu.be/GqiISmXO_78)                                       |
 | 2020-11-17 | [Cloud Native Security Day](https://youtu.be/-I_rCKMyY7Y)                                    |
-| 2021-02-02 | [TPM.Dev Online Call](https://developers.tpm.dev/posts/11542371?utm_source=manual)           |
+| 2021-02-02 | TPM.Dev Online Call: `https://developers.tpm.dev/posts/11542371?utm_source=manual`           |
 | 2021-03-17 | [Using SPIFFE Identities in PARSEC - SPIFFE Commnuity Meeting](https://youtu.be/ahJnTRTJG0A) |
 | 2021-05-03 | [Cloud Native Rust Day](https://youtu.be/49cXCDLALYY)                                        |
 | 2021-05-04 | [KubeCon 2021](https://youtu.be/G-MvFqkVJTI)                                                 |
+| 2021-06-11 | [Confidential Computing Developer Summit](https://youtu.be/mmTpzRVeSoQ)                      |
 
 *Copyright 2020 Contributors to the Parsec project.*


### PR DESCRIPTION
Removes the full link path of one presentation because the link checker
does not pass.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>