### PR TITLE
Draft: CI: Migrate link checker to lychee-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Link Checker
-        id: lc
-        uses: peter-evans/link-checker@v1
-      - name: Fail if there were link errors
-        run: exit ${{ steps.lc.outputs.exit_code }}
+        uses: ruzickap/action-my-markdown-link-checker@v1


### PR DESCRIPTION
peter-evans/link-checker [is deprecated][0] and gives false positives. Use their recommendation and migrate to lycheeverse/lychee-action. As a bonus the new link checker can automatically fail on errors.

[0]: https://github.com/peter-evans/link-checker#warning-this-action-is-deprecated-please-consider-using-lychee-action

P.S.: I actually don't know if it will fix the issue but I figured out that we can try and see what happens. Suggestions welcome! :)